### PR TITLE
Fix memory leak of it and it2 in void ClientCode()

### DIFF
--- a/src/Iterator/Conceptual/main.cc
+++ b/src/Iterator/Conceptual/main.cc
@@ -122,6 +122,8 @@ void ClientCode() {
   for (it2->First(); !it2->IsDone(); it2->Next()) {
     std::cout << it2->Current()->data() << std::endl;
   }
+  delete it;
+  delete it2;
 }
 
 int main() {


### PR DESCRIPTION
In the Iterator C++ example, added delete operations of it and it2 at the end of void ClientCode() to free memory allocated by:

Iterator<int, Container<int>> *it = cont.CreateIterator();
Iterator<Data, Container<Data>> *it2 = cont2.CreateIterator();

Refactoring Guru ticket number: Ticket ID: #1594

Regards

Daniel