### PR TITLE
Fix data race in GetInstance

### DIFF
--- a/src/Singleton/Conceptual/ThreadSafe/main.cc
+++ b/src/Singleton/Conceptual/ThreadSafe/main.cc
@@ -112,13 +112,10 @@ std::mutex Singleton::mutex_;
      */
 Singleton *Singleton::GetInstance(const std::string& value)
 {
+    std::lock_guard<std::mutex> lock(mutex_);
     if (pinstance_ == nullptr)
     {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (pinstance_ == nullptr)
-        {
-            pinstance_ = new Singleton(value);
-        }
+        pinstance_ = new Singleton(value);
     }
     return pinstance_;
 }


### PR DESCRIPTION
In the thread-safe singleton C++ example, fixed data race in the GetInstance method, caused by possible simultaneous read and write to pinstance_.

Refactoring Guru Ticket ID: 1699