### PR TITLE
Fix compile issues across design patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+build/

--- a/src/AbstractFactory/Conceptual/main.cc
+++ b/src/AbstractFactory/Conceptual/main.cc
@@ -137,6 +137,7 @@ class ConcreteProductB2 : public AbstractProductB {
  */
 class AbstractFactory {
  public:
+  virtual ~AbstractFactory() = default;
   virtual AbstractProductA *CreateProductA() const = 0;
   virtual AbstractProductB *CreateProductB() const = 0;
 };

--- a/src/Builder/Conceptual/main.cc
+++ b/src/Builder/Conceptual/main.cc
@@ -181,7 +181,7 @@ class Director{
      * @var Builder
      */
     private:
-    Builder* builder;
+    Builder* builder_;
     /**
      * EN: The Director works with any builder instance that the client code
      * passes to it. This way, the client code may alter the final type of the
@@ -195,7 +195,7 @@ class Director{
     public:
 
     void set_builder(Builder* builder){
-        this->builder=builder;
+        this->builder_=builder;
     }
 
     /**
@@ -207,13 +207,13 @@ class Director{
      */
 
     void BuildMinimalViableProduct(){
-        this->builder->ProducePartA();
+        this->builder_->ProducePartA();
     }
     
     void BuildFullFeaturedProduct(){
-        this->builder->ProducePartA();
-        this->builder->ProducePartB();
-        this->builder->ProducePartC();
+        this->builder_->ProducePartA();
+        this->builder_->ProducePartB();
+        this->builder_->ProducePartC();
     }
 };
 /**

--- a/src/ChainOfResponsibility/Conceptual/main.cc
+++ b/src/ChainOfResponsibility/Conceptual/main.cc
@@ -24,6 +24,7 @@
  */
 class Handler {
  public:
+  virtual ~Handler() = default;
   virtual Handler *SetNext(Handler *handler) = 0;
   virtual std::string Handle(std::string request) = 0;
 };

--- a/src/Composite/Conceptual/main.cc
+++ b/src/Composite/Conceptual/main.cc
@@ -58,8 +58,8 @@ class Component {
      * во время сборки дерева объектов. Недостаток такого подхода в том, что эти
      * методы будут пустыми для компонентов уровня листа.
      */
-  virtual void Add(Component *component) {}
-  virtual void Remove(Component *component) {}
+  virtual void Add(Component *) {}
+  virtual void Remove(Component *) {}
   /**
      * EN: You can provide a method that lets the client code figure out whether
      * a component can bear children.

--- a/src/Facade/Conceptual/main.cc
+++ b/src/Facade/Conceptual/main.cc
@@ -82,8 +82,8 @@ class Facade {
   Facade(
       Subsystem1 *subsystem1 = nullptr,
       Subsystem2 *subsystem2 = nullptr) {
-    this->subsystem1_ = subsystem1 ?: new Subsystem1;
-    this->subsystem2_ = subsystem2 ?: new Subsystem2;
+    this->subsystem1_ = subsystem1 ? subsystem1 : new Subsystem1;
+    this->subsystem2_ = subsystem2 ? subsystem2 : new Subsystem2;
   }
   ~Facade() {
     delete subsystem1_;

--- a/src/Iterator/Conceptual/main.cc
+++ b/src/Iterator/Conceptual/main.cc
@@ -25,7 +25,7 @@ template <typename T, typename U>
 class Iterator {
  public:
   typedef typename std::vector<T>::iterator iter_type;
-  Iterator(U *p_data, bool reverse = false) : m_p_data_(p_data) {
+  Iterator(U *p_data, bool = false) : m_p_data_(p_data) {
     m_it_ = m_p_data_->m_data_.begin();
   }
 

--- a/src/Mediator/Conceptual/main.cc
+++ b/src/Mediator/Conceptual/main.cc
@@ -26,6 +26,7 @@
 class BaseComponent;
 class Mediator {
  public:
+  virtual ~Mediator() = default;
   virtual void Notify(BaseComponent *sender, std::string event) const = 0;
 };
 
@@ -97,7 +98,7 @@ class ConcreteMediator : public Mediator {
     this->component1_->set_mediator(this);
     this->component2_->set_mediator(this);
   }
-  void Notify(BaseComponent *sender, std::string event) const override {
+  void Notify(BaseComponent *, std::string event) const override {
     if (event == "A") {
       std::cout << "Mediator reacts on A and triggers following operations:\n";
       this->component2_->DoC();

--- a/src/Prototype/Conceptual/main.cc
+++ b/src/Prototype/Conceptual/main.cc
@@ -74,6 +74,11 @@ class ConcretePrototype1 : public Prototype {
   Prototype *Clone() const override {
     return new ConcretePrototype1(*this);
   }
+
+  void Method(float prototype_field) override {
+    Prototype::Method(prototype_field);
+    std::cout << "My private data is " << concrete_prototype_field1_ << "\n";
+  }
 };
 
 class ConcretePrototype2 : public Prototype {
@@ -86,6 +91,11 @@ class ConcretePrototype2 : public Prototype {
   }
   Prototype *Clone() const override {
     return new ConcretePrototype2(*this);
+  }
+  
+  void Method(float prototype_field) override {
+    Prototype::Method(prototype_field);
+    std::cout << "My private data is " << concrete_prototype_field2_ << "\n";
   }
 };
 

--- a/src/Proxy/Conceptual/main.cc
+++ b/src/Proxy/Conceptual/main.cc
@@ -23,6 +23,7 @@
  */
 class Subject {
  public:
+  virtual ~Subject() = default;
   virtual void Request() const = 0;
 };
 /**

--- a/src/Strategy/Conceptual/main.cc
+++ b/src/Strategy/Conceptual/main.cc
@@ -129,7 +129,7 @@ class ConcreteStrategyB : public Strategy
             result += letter;
         });
         std::sort(std::begin(result), std::end(result));
-        for (int i = 0; i < result.size() / 2; i++)
+        for (unsigned i = 0; i < result.size() / 2; i++)
         {
             std::swap(result[i], result[result.size() - i - 1]);
         }

--- a/src/TemplateMethod/Conceptual/main.cc
+++ b/src/TemplateMethod/Conceptual/main.cc
@@ -34,6 +34,7 @@ class AbstractClass {
      * RU: Шаблонный метод определяет скелет алгоритма.
      */
  public:
+  virtual ~AbstractClass() = default;
   void TemplateMethod() const {
     this->BaseOperation1();
     this->RequiredOperations1();

--- a/src/Visitor/Conceptual/main.cc
+++ b/src/Visitor/Conceptual/main.cc
@@ -27,6 +27,7 @@ class ConcreteComponentB;
 
 class Visitor {
  public:
+  virtual ~Visitor() = default;
   virtual void VisitConcreteComponentA(const ConcreteComponentA *element) const = 0;
   virtual void VisitConcreteComponentB(const ConcreteComponentB *element) const = 0;
 };


### PR DESCRIPTION
Verified that all design pattern examples build on Windows under clang,
mingw-gcc and MSVC compilers. Changes range from signed/unsigned
mismatch to unused fields and function variables. I'm working on some
new CMakeLists to put in the repo and so this uses those warning
settings which are aggressive.