### PR TITLE
memento: Fix memory leak

### DIFF
--- a/src/Memento/Conceptual/main.cc
+++ b/src/Memento/Conceptual/main.cc
@@ -143,6 +143,7 @@ class Originator {
   void Restore(Memento *memento) {
     this->state_ = memento->state();
     std::cout << "Originator: My state has changed to: " << this->state_ << "\n";
+    delete memento;
   }
 };
 


### PR DESCRIPTION
The memento should be deleted after it is restored.

In a real example you would probably use ``std::shared_ptr`` for this, but I see the advantage of not using too many advanced data structures when teaching about patterns.